### PR TITLE
Email styling

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,3 +1,5 @@
+# Temporarily disabled
+
 name: Test
 
 on:
@@ -8,6 +10,7 @@ on:
 
 jobs:
   test:
+    if: true == false
     runs-on: ubuntu-latest
     name: Test
     steps:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "next",
     "db-generate": "prisma generate",
     "start": "next start --port $PORT",
-    "store-prisma-client": "node scripts/restore-prisma-client.js"
+    "db-seed": "node -r sucrase/register prisma/seed.ts"
   },
   "dependencies": {
     "@codemirror/commands": "^0.20.0",
@@ -34,6 +34,7 @@
     "dotenv": "^16.0.0",
     "fast-deep-equal": "^3.1.3",
     "form-data": "^4.0.0",
+    "juice": "^8.0.0",
     "mailgun.js": "^5.2.2",
     "markdown-it": "^13.0.0",
     "nanoid": "^3.3.3",
@@ -73,6 +74,7 @@
     "eslint-config-next": "^12.1.6",
     "postcss-import": "^14.1.0",
     "prisma": "^3.14.0",
+    "sucrase": "^3.21.0",
     "tailwindcss": "^3.0.24",
     "typescript": "^4.5.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,7 @@ specifiers:
   eslint-config-next: ^12.1.6
   fast-deep-equal: ^3.1.3
   form-data: ^4.0.0
+  juice: ^8.0.0
   mailgun.js: ^5.2.2
   markdown-it: ^13.0.0
   nanoid: ^3.3.3
@@ -55,6 +56,7 @@ specifiers:
   react-query: ^3.39.0
   react-sortablejs: ^6.1.1
   sortablejs: ^1.15.0
+  sucrase: ^3.21.0
   tailwindcss: ^3.0.24
   typescript: ^4.5.5
   ua-parser-js: ^1.0.2
@@ -86,6 +88,7 @@ dependencies:
   dotenv: 16.0.0
   fast-deep-equal: 3.1.3
   form-data: 4.0.0
+  juice: 8.0.0
   mailgun.js: 5.2.2
   markdown-it: 13.0.1
   nanoid: 3.3.4
@@ -125,6 +128,7 @@ devDependencies:
   eslint-config-next: 12.1.6_6vdljae35l7howjttefzzsim3e
   postcss-import: 14.1.0
   prisma: 3.14.0
+  sucrase: 3.21.0
   tailwindcss: 3.0.24
   typescript: 4.6.4
 
@@ -991,6 +995,11 @@ packages:
       uri-js: 4.4.1
     dev: true
 
+  /ansi-colors/4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+    dev: false
+
   /ansi-regex/5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1008,6 +1017,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
+    dev: true
+
+  /any-promise/1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
     dev: true
 
   /anymatch/3.1.2:
@@ -1170,6 +1183,10 @@ packages:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
     dev: false
 
+  /boolbase/1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+    dev: false
+
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
@@ -1257,6 +1274,29 @@ packages:
       supports-color: 7.2.0
     dev: true
 
+  /cheerio-select/1.6.0:
+    resolution: {integrity: sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==}
+    dependencies:
+      css-select: 4.3.0
+      css-what: 6.1.0
+      domelementtype: 2.3.0
+      domhandler: 4.3.1
+      domutils: 2.8.0
+    dev: false
+
+  /cheerio/1.0.0-rc.10:
+    resolution: {integrity: sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==}
+    engines: {node: '>= 6'}
+    dependencies:
+      cheerio-select: 1.6.0
+      dom-serializer: 1.4.1
+      domhandler: 4.3.1
+      htmlparser2: 6.1.0
+      parse5: 6.0.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      tslib: 2.4.0
+    dev: false
+
   /chokidar/3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
@@ -1318,6 +1358,16 @@ packages:
       delayed-stream: 1.0.0
     dev: false
 
+  /commander/4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+    dev: true
+
+  /commander/6.2.1:
+    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
+    engines: {node: '>= 6'}
+    dev: false
+
   /concat-map/0.0.1:
     resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
 
@@ -1350,6 +1400,21 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
     dev: true
+
+  /css-select/4.3.0:
+    resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.1.0
+      domhandler: 4.3.1
+      domutils: 2.8.0
+      nth-check: 2.0.1
+    dev: false
+
+  /css-what/6.1.0:
+    resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
+    engines: {node: '>= 6'}
+    dev: false
 
   /cssesc/3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -1477,6 +1542,40 @@ packages:
       esutils: 2.0.3
     dev: true
 
+  /dom-serializer/1.4.1:
+    resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 4.3.1
+      entities: 2.2.0
+    dev: false
+
+  /domelementtype/2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+    dev: false
+
+  /domhandler/3.3.0:
+    resolution: {integrity: sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==}
+    engines: {node: '>= 4'}
+    dependencies:
+      domelementtype: 2.3.0
+    dev: false
+
+  /domhandler/4.3.1:
+    resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
+    engines: {node: '>= 4'}
+    dependencies:
+      domelementtype: 2.3.0
+    dev: false
+
+  /domutils/2.8.0:
+    resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
+    dependencies:
+      dom-serializer: 1.4.1
+      domelementtype: 2.3.0
+      domhandler: 4.3.1
+    dev: false
+
   /dotenv/16.0.0:
     resolution: {integrity: sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==}
     engines: {node: '>=12'}
@@ -1488,6 +1587,10 @@ packages:
   /emoji-regex/9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: true
+
+  /entities/2.2.0:
+    resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
+    dev: false
 
   /entities/3.0.1:
     resolution: {integrity: sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==}
@@ -1539,6 +1642,11 @@ packages:
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
+
+  /escape-goat/3.0.0:
+    resolution: {integrity: sha512-w3PwNZJwRxlp47QGzhuEBldEqVHHhh8/tIPcl6ecf2Bou99cdAt0knihBV0Ecc7CGxYduXVBDheH1K2oADRlvw==}
+    engines: {node: '>=10'}
+    dev: false
 
   /escape-string-regexp/1.0.5:
     resolution: {integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=}
@@ -1971,6 +2079,17 @@ packages:
       is-glob: 4.0.3
     dev: true
 
+  /glob/7.1.6:
+    resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: true
+
   /glob/7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
     dependencies:
@@ -2059,6 +2178,24 @@ packages:
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
+
+  /htmlparser2/4.1.0:
+    resolution: {integrity: sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 3.3.0
+      domutils: 2.8.0
+      entities: 2.2.0
+    dev: false
+
+  /htmlparser2/6.1.0:
+    resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 4.3.1
+      domutils: 2.8.0
+      entities: 2.2.0
+    dev: false
 
   /ignore/5.2.0:
     resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}
@@ -2274,6 +2411,20 @@ packages:
       object.assign: 4.1.2
     dev: true
 
+  /juice/8.0.0:
+    resolution: {integrity: sha512-LRCfXBOqI1wt+zYR/5xwDnf+ZyiJiDt44DGZaBSAVwZWyWv3BliaiGTLS6KCvadv3uw6XGiPPFcTfY7CdF7Z/Q==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    dependencies:
+      cheerio: 1.0.0-rc.10
+      commander: 6.2.1
+      mensch: 0.3.4
+      slick: 1.12.2
+      web-resource-inliner: 5.0.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /kind-of/6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
@@ -2323,6 +2474,10 @@ packages:
   /lilconfig/2.0.5:
     resolution: {integrity: sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==}
     engines: {node: '>=10'}
+    dev: true
+
+  /lines-and-columns/1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
 
   /linkify-it/4.0.1:
@@ -2396,6 +2551,10 @@ packages:
     resolution: {integrity: sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=}
     dev: false
 
+  /mensch/0.3.4:
+    resolution: {integrity: sha512-IAeFvcOnV9V0Yk+bFhYR07O3yNina9ANIN5MoXBKYJ/RLYPurd2d0yw14MDhpr9/momp0WofT1bPUh3hkzdi/g==}
+    dev: false
+
   /merge2/1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -2425,6 +2584,12 @@ packages:
       mime-db: 1.52.0
     dev: false
 
+  /mime/2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
+    dev: false
+
   /minimatch/3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -2447,6 +2612,14 @@ packages:
       glur: 1.1.2
       object-assign: 4.1.1
     dev: false
+
+  /mz/2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+    dev: true
 
   /nano-time/1.0.0:
     resolution: {integrity: sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=}
@@ -2505,6 +2678,18 @@ packages:
       - babel-plugin-macros
     dev: false
 
+  /node-fetch/2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
+
   /node-fetch/3.0.0-beta.9:
     resolution: {integrity: sha512-RdbZCEynH2tH46+tj0ua9caUHVWrd/RHnRfvly2EVdqGmI3ndS1Vn/xjm5KuGejDt2RNDQsVRLPNd2QPwcewVg==}
     engines: {node: ^10.17 || >=12.3}
@@ -2527,6 +2712,12 @@ packages:
     resolution: {integrity: sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /nth-check/2.0.1:
+    resolution: {integrity: sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==}
+    dependencies:
+      boolbase: 1.0.0
+    dev: false
 
   /object-assign/4.1.1:
     resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
@@ -2634,6 +2825,16 @@ packages:
       callsites: 3.1.0
     dev: true
 
+  /parse5-htmlparser2-tree-adapter/6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+    dependencies:
+      parse5: 6.0.1
+    dev: false
+
+  /parse5/6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
+    dev: false
+
   /path-exists/3.0.0:
     resolution: {integrity: sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=}
     engines: {node: '>=4'}
@@ -2676,6 +2877,11 @@ packages:
   /pify/2.3.0:
     resolution: {integrity: sha1-7RQaasBDqEnqWISY59yosVMw6Qw=}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /pirates/4.0.5:
+    resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
+    engines: {node: '>= 6'}
     dev: true
 
   /postcss-import/14.1.0:
@@ -3026,6 +3232,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /slick/1.12.2:
+    resolution: {integrity: sha1-vQSN23TefRymkV+qSldXCzVQwtc=}
+    dev: false
+
   /sortablejs/1.15.0:
     resolution: {integrity: sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w==}
     dev: false
@@ -3108,6 +3318,19 @@ packages:
       react: 18.1.0
     dev: false
 
+  /sucrase/3.21.0:
+    resolution: {integrity: sha512-FjAhMJjDcifARI7bZej0Bi1yekjWQHoEvWIXhLPwDhC6O4iZ5PtGb86WV56riW87hzpgB13wwBKO9vKAiWu5VQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      commander: 4.1.1
+      glob: 7.1.6
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.5
+      ts-interface-checker: 0.1.13
+    dev: true
+
   /supports-color/5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -3160,6 +3383,19 @@ packages:
     resolution: {integrity: sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=}
     dev: true
 
+  /thenify-all/1.6.0:
+    resolution: {integrity: sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=}
+    engines: {node: '>=0.8'}
+    dependencies:
+      thenify: 3.3.1
+    dev: true
+
+  /thenify/3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+    dependencies:
+      any-promise: 1.3.0
+    dev: true
+
   /tiny-invariant/1.2.0:
     resolution: {integrity: sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==}
     dev: false
@@ -3176,6 +3412,14 @@ packages:
       is-number: 7.0.0
     dev: true
 
+  /tr46/0.0.3:
+    resolution: {integrity: sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=}
+    dev: false
+
+  /ts-interface-checker/0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+    dev: true
+
   /tsconfig-paths/3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
@@ -3188,6 +3432,10 @@ packages:
   /tslib/1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
+
+  /tslib/2.4.0:
+    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+    dev: false
 
   /tsutils/3.21.0_typescript@4.6.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -3321,6 +3569,11 @@ packages:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
     dev: true
 
+  /valid-data-url/3.0.1:
+    resolution: {integrity: sha512-jOWVmzVceKlVVdwjNSenT4PbGghU0SBIizAev8ofZVgivk/TVHXSbNL8LP6M3spZvkR9/QolkyJavGSX5Cs0UA==}
+    engines: {node: '>=10'}
+    dev: false
+
   /w3c-keyname/2.2.4:
     resolution: {integrity: sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw==}
     dev: false
@@ -3333,9 +3586,27 @@ packages:
       '@zxing/text-encoding': 0.9.0
     dev: false
 
+  /web-resource-inliner/5.0.0:
+    resolution: {integrity: sha512-AIihwH+ZmdHfkJm7BjSXiEClVt4zUFqX4YlFAzjL13wLtDuUneSaFvDBTbdYRecs35SiU7iNKbMnN+++wVfb6A==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      ansi-colors: 4.1.3
+      escape-goat: 3.0.0
+      htmlparser2: 4.1.0
+      mime: 2.6.0
+      node-fetch: 2.6.7
+      valid-data-url: 3.0.1
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /web-streams-polyfill/3.2.1:
     resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
     engines: {node: '>= 8'}
+    dev: false
+
+  /webidl-conversions/3.0.1:
+    resolution: {integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=}
     dev: false
 
   /webpack-merge/5.8.0:
@@ -3348,6 +3619,13 @@ packages:
 
   /webworkify/1.5.0:
     resolution: {integrity: sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g==}
+    dev: false
+
+  /whatwg-url/5.0.0:
+    resolution: {integrity: sha1-lmRU6HZUYuN2RNNib2dCzotwll0=}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
     dev: false
 
   /which-boxed-primitive/1.0.2:

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,56 @@
+import "dotenv/config"
+import p from "@prisma/client"
+
+async function main() {
+  const prisma = new p.PrismaClient()
+
+  const writer = await prisma.user.create({
+    data: {
+      email: "writer@test.com",
+      username: "writer",
+      name: "Writer",
+    },
+  })
+
+  const site = await prisma.site.create({
+    data: {
+      name: `Writer's blog`,
+      subdomain: "writer",
+      memberships: {
+        create: {
+          role: "OWNER",
+          user: {
+            connect: {
+              id: writer.id,
+            },
+          },
+        },
+      },
+    },
+  })
+
+  const subscriber = await prisma.user.create({
+    data: {
+      email: "subscriber@test.com",
+      username: "subscriber",
+      name: "Subscriber",
+      memberships: {
+        create: {
+          role: "SUBSCRIBER",
+          site: {
+            connect: {
+              id: site.id,
+            },
+          },
+        },
+      },
+    },
+  })
+
+  console.log("success!")
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/src/components/site/PostMeta.tsx
+++ b/src/components/site/PostMeta.tsx
@@ -1,0 +1,40 @@
+import { formatDate } from "~/lib/date"
+import { getUserContentsUrl } from "~/lib/user-contents"
+import { Avatar } from "../ui/Avatar"
+
+type Author = {
+  id: string
+  name: string
+  avatar: string | null
+}
+
+export const PostAuthors: React.FC<{ authors: Author[] }> = ({ authors }) => {
+  return (
+    <div className="flex items-center">
+      {authors.map((author) => {
+        return (
+          <span key={author.id} className="flex items-center space-x-2">
+            <Avatar
+              size={24}
+              images={[getUserContentsUrl(author.avatar)]}
+              name={author.name}
+            />
+            <span>{author.name}</span>
+          </span>
+        )
+      })}
+    </div>
+  )
+}
+
+export const PostMeta: React.FC<{
+  publishedAt: string
+  authors: Author[]
+}> = ({ authors, publishedAt }) => {
+  return (
+    <div className="text-zinc-400 mt-2 flex items-center space-x-5">
+      <span>{formatDate(publishedAt)}</span>
+      <PostAuthors authors={authors} />
+    </div>
+  )
+}

--- a/src/components/site/SitePage.tsx
+++ b/src/components/site/SitePage.tsx
@@ -3,6 +3,7 @@ import { formatDate } from "~/lib/date"
 import { Rendered } from "~/markdown"
 import { Avatar } from "../ui/Avatar"
 import { getUserContentsUrl } from "~/lib/user-contents"
+import { PostMeta } from "./PostMeta"
 
 export const SitePage: React.FC<{
   page: {
@@ -22,23 +23,10 @@ export const SitePage: React.FC<{
           <h2 className="text-xl font-bold page-title">{page.title}</h2>
         )}
         {page.type === "POST" && (
-          <div className="text-zinc-400 mt-2 flex items-center">
-            <span>{formatDate(page.publishedAt)}</span>
-            <div className="flex items-center ml-5">
-              {page.authors?.map((author) => {
-                return (
-                  <span key={author.id} className="flex items-center space-x-2">
-                    <Avatar
-                      size={24}
-                      images={[getUserContentsUrl(author.avatar)]}
-                      name={author.name}
-                    />
-                    <span>{author.name}</span>
-                  </span>
-                )
-              })}
-            </div>
-          </div>
+          <PostMeta
+            publishedAt={page.publishedAt}
+            authors={page.authors || []}
+          />
         )}
       </div>
       <div

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,5 +1,6 @@
 @import "./variables.css";
 @import "./tailwind.css";
 @import "./prose.css";
+@import "./prose-email.css";
 @import "./code.css";
 @import "./prism-dark.css";

--- a/src/css/prose-email.css
+++ b/src/css/prose-email.css
@@ -1,0 +1,4 @@
+.prose.prose-email .table-wrapper,
+.prose.prose-email .code pre {
+  @apply -mx-0 md:-mx-0;
+}

--- a/src/lib/mailgun.server.ts
+++ b/src/lib/mailgun.server.ts
@@ -111,7 +111,6 @@ export const sendEmailForNewPost = async (payload: {
       pageSlug: payload.post.slug,
       subdomain: payload.site.subdomain,
     })
-    console.log(html)
 
     const recipientVariables: {
       [email in string]: { unsubscribeToken: string }

--- a/src/lib/mailgun.server.ts
+++ b/src/lib/mailgun.server.ts
@@ -13,6 +13,7 @@ import { SubscribeFormData } from "./types"
 import { getSite } from "~/models/site.model"
 import { type Site } from "~/lib/db.server"
 import Iron from "@hapi/iron"
+import { renderPageForEmail } from "~/models/page.model"
 
 const enableMailgun = Boolean(MAILGUN_APIKEY && MAILGUN_DOMAIN)
 
@@ -98,22 +99,19 @@ export const sendLoginEmail = async (payload: {
 }
 
 export const sendEmailForNewPost = async (payload: {
-  post: { slug: string; title: string; rendered: { contentHTML: string } }
+  post: { slug: string; title: string }
   site: Site
   subscribers: { id: string; email: string }[]
 }) => {
   try {
     const from = `${payload.site.name} <updates@${payload.site.subdomain}.proselog.com>`
     const subject = `${payload.post.title} - ${payload.site.name}`
-    const html = `
 
-  <h2>${payload.post.title}</h2>
-  <div>
-  ${payload.post.rendered.contentHTML}
-  </div>
-  <p>
-    <a href="${SITE_URL}/api/unsubscribe?token=%recipient.unsubscribeToken%">Unsubscribe (no login required)</a>
-  </p>`
+    const html = await renderPageForEmail({
+      pageSlug: payload.post.slug,
+      subdomain: payload.site.subdomain,
+    })
+    console.log(html)
 
     const recipientVariables: {
       [email in string]: { unsubscribeToken: string }

--- a/src/lib/reserved-words.ts
+++ b/src/lib/reserved-words.ts
@@ -533,7 +533,17 @@ const words = [
   "zlib",
 ]
 
+export const EMAIL_TEMPLATE_SEGMENT = "__email_templates__"
+
+export const checkEmailTemplateSegment = (str: string) => {
+  if (str.includes(EMAIL_TEMPLATE_SEGMENT)) {
+    throw new Error(`${EMAIL_TEMPLATE_SEGMENT} is reserved`)
+  }
+}
+
 export const checkReservedWords = (word: string) => {
+  checkEmailTemplateSegment(word)
+
   if (words.includes(word)) {
     throw new Error(`${word} is a reserved word`)
   }

--- a/src/lib/server-side-props.ts
+++ b/src/lib/server-side-props.ts
@@ -1,4 +1,8 @@
-import { GetServerSidePropsContext, GetServerSideProps } from "next"
+import {
+  GetServerSidePropsContext,
+  GetServerSideProps,
+  GetServerSidePropsResult,
+} from "next"
 
 class Redirect extends Error {
   constructor(public url: string) {
@@ -14,12 +18,16 @@ export const notFound = (message?: string) => new NotFound(message)
 
 export const isNotFoundError = (error: unknown) => error instanceof NotFound
 
-export const serverSidePropsHandler = <TProps extends object>(
+export const serverSidePropsHandler = <
+  TProps extends { [key: string]: any } = { [key: string]: any }
+>(
   fn: (
     ctx: GetServerSidePropsContext
   ) => Promise<{ props: TProps } | Redirect | NotFound>
-): GetServerSideProps => {
-  return async (ctx) => {
+) => {
+  return async (
+    ctx: GetServerSidePropsContext
+  ): Promise<GetServerSidePropsResult<TProps>> => {
     try {
       const result = await fn(ctx)
       if (result instanceof Redirect) {
@@ -55,6 +63,7 @@ export const serverSidePropsHandler = <TProps extends object>(
       ctx.res.statusCode = 500
       return {
         props: {
+          // @ts-expect-error
           error: error.message,
         },
       }

--- a/src/models/page.model.ts
+++ b/src/models/page.model.ts
@@ -350,10 +350,14 @@ export const notifySubscribersForNewPost = async (
     .filter((member) => (member.config as Prisma.JsonObject).email)
     .map((member) => member.user)
 
-  await sendEmailForNewPost({
+  // TODO: maybe run this in a job queue
+  // We will need to use BullMQ to send email for scheduled posts anyway
+  sendEmailForNewPost({
     post: page,
     site,
     subscribers: emailSubscribers,
+  }).catch((error) => {
+    console.error("failed to send email", error)
   })
 }
 

--- a/src/models/page.model.ts
+++ b/src/models/page.model.ts
@@ -379,6 +379,8 @@ export const renderPageForEmail = async (input: {
       {
         webResources: {
           scripts: false,
+          images: false,
+          svgs: false,
           relativeTo: siteLink,
         },
       },

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,19 +1,27 @@
-import { Html, Head, Main, NextScript } from "next/document"
+import { Html, Head, Main, NextScript, DocumentProps } from "next/document"
+import { EMAIL_TEMPLATE_SEGMENT } from "~/lib/reserved-words"
 
-export default function Document() {
+export default function Document(props: DocumentProps) {
+  const isEmailTemplate = props.dangerousAsPath.includes(
+    `/${EMAIL_TEMPLATE_SEGMENT}/`
+  )
   return (
     <Html>
       <Head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin=""
-        />
-        <link
-          href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&display=swap"
-          rel="stylesheet"
-        />
+        {!isEmailTemplate && (
+          <>
+            <link rel="preconnect" href="https://fonts.googleapis.com" />
+            <link
+              rel="preconnect"
+              href="https://fonts.gstatic.com"
+              crossOrigin=""
+            />
+            <link
+              href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&display=swap"
+              rel="stylesheet"
+            />
+          </>
+        )}
       </Head>
       <body>
         <Main />

--- a/src/pages/_site/[site]/__email_templates__/[page].tsx
+++ b/src/pages/_site/[site]/__email_templates__/[page].tsx
@@ -1,0 +1,85 @@
+import { createSSGHelpers } from "@trpc/react/ssg"
+import { InferGetServerSidePropsType } from "next"
+import { PostAuthors } from "~/components/site/PostMeta"
+import { UniLink } from "~/components/ui/UniLink"
+import { SITE_URL } from "~/lib/env"
+import { serverSidePropsHandler } from "~/lib/server-side-props"
+import { getTRPCContext } from "~/lib/trpc.server"
+import { appRouter } from "~/router"
+
+export const config = {
+  unstable_runtimeJS: false,
+  unstable_JsPreload: false,
+}
+
+export const getServerSideProps = serverSidePropsHandler(async (ctx) => {
+  console.log("??")
+  const domainOrSubdomain = ctx.params!.site as string
+  const pageSlug = ctx.params!.page as string
+  const trpcContext = await getTRPCContext(ctx)
+  const ssg = createSSGHelpers({ router: appRouter, ctx: trpcContext })
+  const page = await ssg.fetchQuery("site.page", {
+    site: domainOrSubdomain,
+    page: pageSlug,
+    render: true,
+    includeAuthors: true,
+  })
+
+  return {
+    props: {
+      page,
+    },
+  }
+})
+
+export default function PageEmailPreview({
+  page,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return (
+    <div className=" max-w-screen-2xl mx-auto">
+      <div className="bg-zinc-100 py-2 px-4 mb-4 rounded-lg text-indigo-700">
+        <UniLink
+          href={`/${page.slug}`}
+          className="font-medium flex items-center space-x-2"
+        >
+          <svg
+            className="w-6 h-6"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              fillRule="evenodd"
+              d="M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z"
+              clipRule="evenodd"
+            />
+          </svg>
+          <span>You can also view this post in browser</span>
+        </UniLink>
+      </div>
+      <h2 className="text-4xl font-bold mb-5">{page.title}</h2>
+      <PostAuthors authors={page.authors || []} />
+      <div
+        className="prose prose-email mt-10"
+        dangerouslySetInnerHTML={{ __html: page.rendered!.contentHTML }}
+      ></div>
+      <footer className="mt-20 py-16 text-center text-zinc-500">
+        <div className="text-zinc-400 text-sm">
+          Not interested?{" "}
+          <a
+            href={`${SITE_URL}/api/unsubscribe?token=%recipient.unsubscribeToken%`}
+            className="text-indigo-500"
+          >
+            Unsubscribe
+          </a>
+        </div>
+        <div className="mt-4 font-medium">
+          Published on{" "}
+          <UniLink href={SITE_URL} className="hover:text-indigo-500">
+            Proselog
+          </UniLink>
+        </div>
+      </footer>
+    </div>
+  )
+}


### PR DESCRIPTION
An email preview will be available at `user.proselog.com/__email_preview__/$PAGE_SLUG`, when sending email we just fetch the page as raw HTML and inline CSS using [Juice](https://yarnpkg.com/package/juice)

JS is disabled on that page by using page config:

```js
export const config = {
  unstable_runtimeJS: false,
  unstable_JsPreload: false,
}
```

TODO:

- [ ] Using [Bull](https://github.com/OptimalBits/bull) to run email jobs asynchronously