### PR TITLE
Minor changes relating to `trpc-openapi` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "mdast-util-to-string": "^3.1.0",
     "nanoid": "^3.3.3",
     "next": "^12.2.5",
+    "nextjs-cors": "^2.1.1",
     "pica": "^9.0.1",
     "posthtml": "^0.16.6",
     "prismjs": "^1.28.0",

--- a/src/pages/api/v0/[...trpc].ts
+++ b/src/pages/api/v0/[...trpc].ts
@@ -1,8 +1,18 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import cors from 'nextjs-cors';
 import { createOpenApiNextHandler } from "trpc-openapi"
 import { getTRPCContext } from "~/lib/trpc.server"
 import { appRouter } from "~/router"
 
-export default createOpenApiNextHandler({
-  router: appRouter,
-  createContext: getTRPCContext,
-})
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  // Setup CORS
+  await cors(req, res);
+  
+  // Handle incoming OpenAPI requests
+  return createOpenApiNextHandler({
+    router: appRouter,
+    createContext: getTRPCContext,
+  })(req, res);
+};
+
+export default handler;

--- a/src/router/site.ts
+++ b/src/router/site.ts
@@ -183,6 +183,7 @@ export const siteRouter = createRouter()
         path: `/site/{site}`,
         method: "PATCH",
         summary: `Update a site`,
+        protect: true,
       },
     },
     input: z.object({
@@ -229,6 +230,7 @@ export const siteRouter = createRouter()
         path: `/site`,
         method: "POST",
         summary: `Create a site`,
+        protect: true,
       },
     },
     input: z.object({
@@ -275,6 +277,7 @@ export const siteRouter = createRouter()
         path: `/site/{siteId}/unsubscribe`,
         method: "POST",
         summary: `Unsubscribe to a site`,
+        protect: true,
       },
     },
     input: z.object({

--- a/src/router/site.ts
+++ b/src/router/site.ts
@@ -23,7 +23,7 @@ export const siteRouter = createRouter()
         enabled: true,
         method: "GET",
         path: "/site/{site}",
-        description: `Get a single site`,
+        summary: `Get a single site`,
       },
     },
     input: z.object({
@@ -58,7 +58,7 @@ export const siteRouter = createRouter()
         enabled: true,
         path: `/site/{site}/my-subscription`,
         method: "GET",
-        description: `Get the subscription for current viewer`,
+        summary: `Get the subscription for current viewer`,
       },
     },
     input: z.object({
@@ -88,7 +88,7 @@ export const siteRouter = createRouter()
         enabled: true,
         path: `/site/{site}/pages`,
         method: "GET",
-        description: `Get pages for a site`,
+        summary: `Get pages for a site`,
       },
     },
     input: z.object({
@@ -134,7 +134,7 @@ export const siteRouter = createRouter()
         enabled: true,
         path: `/site/{site}/page/{page}`,
         method: "GET",
-        description: `Get a single page from a site`,
+        summary: `Get a single page from a site`,
       },
     },
     input: z.object({
@@ -182,7 +182,7 @@ export const siteRouter = createRouter()
         enabled: true,
         path: `/site/{site}`,
         method: "PATCH",
-        description: `Update a site`,
+        summary: `Update a site`,
       },
     },
     input: z.object({
@@ -228,7 +228,7 @@ export const siteRouter = createRouter()
         enabled: true,
         path: `/site`,
         method: "POST",
-        description: `Create a site`,
+        summary: `Create a site`,
       },
     },
     input: z.object({
@@ -250,7 +250,7 @@ export const siteRouter = createRouter()
         enabled: true,
         path: `/site/{siteId}/subscribe`,
         method: "POST",
-        description: `Subscribe to a site`,
+        summary: `Subscribe to a site`,
       },
     },
     input: z.object({
@@ -274,7 +274,7 @@ export const siteRouter = createRouter()
         enabled: true,
         path: `/site/{siteId}/unsubscribe`,
         method: "POST",
-        description: `Unsubscribe to a site`,
+        summary: `Unsubscribe to a site`,
       },
     },
     input: z.object({


### PR DESCRIPTION
## Minor changes relating to `trpc-openapi`

Hi @egoist, I'm the maintainer of [`trpc-openapi`](https://github.com/jlalmes/trpc-openapi), saw your project was open source so thought I'd contribute some minor fixes. Looks great btw! 🎉🚀

### Changes

* Added `cors` so that your OpenAPI enabled endpoints are publicly accessible. 
* Changed `description` to `summary` (looks better on swagger).
* Added `protect: true` to endpoints that require authentication to access.

### TRPCError

An additional thought.. you should be throwing `TRPCError` (instead of `Error`) throughout your API so that your response status codes & payloads are consistent with the APIs behaviour. 

#### Example

_Currently_, if I make a request to `POST /api/v0/site` without an `Authorization` header credential then you receive a response with status code `500`:
```json
{
  "ok": false,
  "error": {
    "message": "unauthorized",
    "code": "INTERNAL_SERVER_ERROR"
  }
}
```

_However_, if you change the following line:
```diff
// src/lib/gate.server.ts

if (requireAuth && !user) {
-  throw new Error("unauthorized")
+  throw new TRPCError({ message: "unauthorized", code: "UNAUTHORIZED" })
}
```
Then the resulting response of the same request will have status code `401` and body: 
```json
{
  "ok": false,
  "error": {
    "message": "unauthorized",
    "code": "UNAUTHORIZED"
  }
}
```
